### PR TITLE
Add exception handling to infinite loops

### DIFF
--- a/index/repositories.py
+++ b/index/repositories.py
@@ -110,8 +110,12 @@ class Notification(object):
         receives notifications and integrate them in the scheduling.
         """
         while True:
-            yield self._check_for_notifications()
-            yield sleep(options.notification_poll_interval)
+            try:
+                yield self._check_for_notifications()
+                yield sleep(options.notification_poll_interval)
+            except Exception as e:
+                logging.exception('Error checking for notifications')
+                pass
 
     @coroutine
     def _check_for_notifications(self, max_notifications=20):
@@ -242,8 +246,12 @@ class RepositoryStore(object):
         """
 
         while True:
-            yield self._fetch_repositories()
-            yield sleep(options.accounts_poll_interval)
+            try:
+                yield self._fetch_repositories()
+                yield sleep(options.accounts_poll_interval)
+            except Exception:
+                logging.exception('Error fetching repositories')
+                pass
 
     @coroutine
     def _fetch_repositories(self):
@@ -494,9 +502,13 @@ class Manager(object):
     def fetch_forever(self):
         """Fetch entities from repository services and reschedule"""
         while True:
-            ids = yield self.scheduler.get(options.concurrency)
-            yield [self.fetch(repo_id) for repo_id in ids]
-            yield sleep(min(options.notification_poll_interval, 1))
+            try:
+                ids = yield self.scheduler.get(options.concurrency)
+                yield [self.fetch(repo_id) for repo_id in ids]
+                yield sleep(min(options.notification_poll_interval, 1))
+            except Exception:
+                logging.exception('Error fetching entities')
+                pass
 
     @coroutine
     def fetch(self, repo_id):


### PR DESCRIPTION
The exception handling ensures the loops continue even if there is an exception. To fully protect the process we need to split it out of the index service have something like supervisord manage it.